### PR TITLE
Revert "Switches mutations to use ID specific finders"

### DIFF
--- a/app/graphql/mutations/add_entity_from_content_to_collection.rb
+++ b/app/graphql/mutations/add_entity_from_content_to_collection.rb
@@ -10,7 +10,7 @@ module Mutations
     field :entity, Types::EntityType, null: false
 
     def resolve(id:, content_id:)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
       existing_content = current_user.contents.find(content_id)
       entity = existing_content.entity
       content = collection.contents.create!(user: current_user, entity: entity)

--- a/app/graphql/mutations/add_entity_to_collection.rb
+++ b/app/graphql/mutations/add_entity_to_collection.rb
@@ -10,7 +10,7 @@ module Mutations
     field :entity, Types::EntityType, null: false
 
     def resolve(id:, entity:)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
       method = entity.type.name.downcase.underscore.pluralize.to_sym
       entity = current_user.send(method).find(entity.id)
       content = collection.contents.create!(user: current_user, entity: entity)

--- a/app/graphql/mutations/add_to_collection.rb
+++ b/app/graphql/mutations/add_to_collection.rb
@@ -13,7 +13,7 @@ module Mutations
     field :entity, Types::EntityType, null: false
 
     def resolve(id:, value:, metadata: nil)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
 
       ActiveRecord::Base.transaction do
         entity = Entity::Builder.build(user: current_user, value: value)

--- a/app/graphql/mutations/delete_collection.rb
+++ b/app/graphql/mutations/delete_collection.rb
@@ -7,7 +7,7 @@ module Mutations
     field :me, Types::UserType, null: false
 
     def resolve(id:)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
       collection.destroy
       { me: current_user }
     end

--- a/app/graphql/mutations/publish_collection.rb
+++ b/app/graphql/mutations/publish_collection.rb
@@ -8,7 +8,7 @@ module Mutations
     field :collection, Types::CollectionType, null: false
 
     def resolve(id:, regenerate: false)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
 
       collection.update_attributes!(key: SecureRandom.uuid) if !collection.published? || regenerate
 

--- a/app/graphql/mutations/unpublish_collection.rb
+++ b/app/graphql/mutations/unpublish_collection.rb
@@ -7,7 +7,7 @@ module Mutations
     field :collection, Types::CollectionType, null: false
 
     def resolve(id:)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
       collection.update_attributes!(key: nil)
 
       { collection: collection }

--- a/app/graphql/mutations/update_collection.rb
+++ b/app/graphql/mutations/update_collection.rb
@@ -12,7 +12,7 @@ module Mutations
     field :collection, Types::CollectionType, null: false
 
     def resolve(id:, title: nil, metadata: {}, replace:)
-      collection = current_user.collections.find_by_id!(id)
+      collection = current_user.collections.find(id)
       next_metadata = (replace ? metadata : collection.metadata.merge(metadata).compact)
                       .reject { |k, _| k.blank? } # Empty keys removes fields
 

--- a/spec/graphql/mutations/add_to_collection_spec.rb
+++ b/spec/graphql/mutations/add_to_collection_spec.rb
@@ -9,7 +9,6 @@ describe 'AddToCollection' do
         addToCollection(input: { id: $id, value: $value, metadata: $metadata }) {
           collection {
             id
-            title
             contents {
               id
               metadata
@@ -28,7 +27,7 @@ describe 'AddToCollection' do
   end
 
   let!(:current_user) { Fabricate(:user) }
-  let!(:collection) { Fabricate(:collection, user: current_user, title: "A Collection") }
+  let!(:collection) { Fabricate(:collection, user: current_user) }
 
   let :response do
     execute mutation,
@@ -68,19 +67,6 @@ describe 'AddToCollection' do
       expect(content['metadata']['bar']).to eql('baz')
       expect(content['entity']['__typename']).to eql('Text')
       expect(content['entity']['body']).to eql('Hello world')
-    end
-  end
-
-  describe 'a collection whose slug conflicts with a numeric id' do
-    let!(:collection_with_conflicting_slug_id) { Fabricate(:collection, user: current_user, title: collection.id) }
-
-    it 'requires the id (not slug) of the collection for adding' do
-      response_collection = response['data']['addToCollection']['collection']
-      content = response['data']['addToCollection']['collection']['contents'].first
-      expect(response_collection['id']).to eql(collection.id)
-      expect(response_collection['title']).to eql("A Collection")
-      expect(content['entity']['__typename']).to eql('Text')
-      expect(content['entity']['body']).to eql('Goodbye world')
     end
   end
 end


### PR DESCRIPTION
Reverts auspices/atlas#64

Need to fix up both the type safety on the mutations themselves and the client in places before merging the fix.